### PR TITLE
:sparkles: Disable AOS animations on mobile

### DIFF
--- a/assets/scss/_global.scss
+++ b/assets/scss/_global.scss
@@ -18,23 +18,6 @@
   }
 }
 
-/* ==========================
-  PAGE TRANSITIONS
-  ============================= */
-.page-leave-active {
-  transition: opacity 0.15s 0s cubic-bezier(0.39, 0.57, 0.56, 1);
-}
-
-.page-enter-active,
-.page-leave-active {
-  transition: opacity 0.25s 0.1s cubic-bezier(0.39, 0.57, 0.56, 1), transform 0.55s cubic-bezier(0.39, 0.57, 0.56, 1);
-}
-
-.page-enter-from,
-.page-leave-to {
-  opacity: 0;
-}
-
 .container {
   &-slim {
     @include media-breakpoint-up(lg) {
@@ -93,5 +76,14 @@
 
   & + & {
     margin-top: 2.5rem;
+  }
+}
+
+[data-aos],
+.aos-init {
+  @include media-breakpoint-down(md) {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
   }
 }


### PR DESCRIPTION
Disabled AOS animations on mobile devices via CSS as direct config changes resulted in unwanted outcomes when routing